### PR TITLE
:indexed transcoder hint support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ pom.xml
 .lein-failures
 .lein-plugins
 .lein-env
+.nrepl-port

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+/target
+/lib
+/classes
+/checkouts
+pom.xml
+*.jar
+*.class
+.lein-deps-sum
+.lein-failures
+.lein-plugins
+.lein-env

--- a/src/tikkba/transcoder.clj
+++ b/src/tikkba/transcoder.clj
@@ -4,14 +4,15 @@
            [org.apache.batik.transcoder.image PNGTranscoder JPEGTranscoder]
            [org.apache.batik.transcoder TranscoderInput TranscoderOutput]))
 
-(def png-transcoder-hints {:height PNGTranscoder/KEY_HEIGHT
-                           :width PNGTranscoder/KEY_WIDTH})
+(def png-transcoder-hints {:height [PNGTranscoder/KEY_HEIGHT float]
+                           :width [PNGTranscoder/KEY_WIDTH float]
+                           :indexed [PNGTranscoder/KEY_INDEXED int]})
 
 (def default-png-options {})
 
-(def jpeg-transcoder-hints {:quality JPEGTranscoder/KEY_QUALITY
-                            :height JPEGTranscoder/KEY_HEIGHT
-                            :width JPEGTranscoder/KEY_WIDTH})
+(def jpeg-transcoder-hints {:quality [JPEGTranscoder/KEY_QUALITY float]
+                            :height [JPEGTranscoder/KEY_HEIGHT float]
+                            :width [JPEGTranscoder/KEY_WIDTH float]})
 
 (def default-jpeg-options {:quality 1})
 
@@ -25,8 +26,8 @@
   "Function that applies supported options to the transcoder.
   Returns: transcoder object"
   (doseq [[option value] options]
-    (when-let [opt-key (-> option keyword hints-map)]
-      (.addTranscodingHint transcoder opt-key (float value))))
+    (when-let [[opt-key coerce] (-> option keyword hints-map)]
+      (.addTranscodingHint transcoder opt-key (coerce value))))
   transcoder)
 
 (defn- transcode-doc [transcoder doc output-path]

--- a/test/tikkba/test/core.clj
+++ b/test/tikkba/test/core.clj
@@ -1,6 +1,0 @@
-(ns tikkba.test.core
-  (:use [tikkba.core] :reload)
-  (:use [clojure.test]))
-
-(deftest replace-me ;; FIXME: write
-  (is false "No tests have been written."))

--- a/test/tikkba/test/transcoder.clj
+++ b/test/tikkba/test/transcoder.clj
@@ -5,16 +5,17 @@
             [analemma.svg :refer [svg rect]]
             [analemma.xml :as xml]
             [clojure.java.io :as io])
-  (:import [javax.imageio ImageIO]))
+  (:import [javax.imageio ImageIO]
+           [java.awt.image BufferedImage]))
 
 (def png-output-path "/tmp/test_tikkba_transcoder.png")
 (def jpeg-output-path "/tmp/test_tikkba_transcoder.jpeg")
 
 (defn- make-dummy-svg []
   (svg-doc
-    (svg 
-      (-> (rect 0 10 50 400)
-          (xml/add-attrs :fill "red")))))
+   (svg 
+    (-> (rect 0 10 50 400)
+        (xml/add-attrs :fill "red")))))
 
 (deftest test-does-png-transcoder-work-without-options
   (io/delete-file png-output-path true) 
@@ -22,10 +23,10 @@
         result-path (t/to-png the-doc png-output-path)]
     (is (-> result-path nil? not))
     (is (= png-output-path result-path))
-    (is (.exists (io/as-file result-path))))
-    (io/delete-file png-output-path true))
+    (is (.exists (io/as-file result-path)))
+    (io/delete-file png-output-path true)))
 
-(deftest test-does-png-transoder-work-with-options
+(deftest test-does-png-transcoder-work-with-options
   (io/delete-file png-output-path true) 
   (let [options {:width 128 :height 64}
         the-doc (make-dummy-svg)
@@ -34,8 +35,8 @@
     (is (= png-output-path result-path))
     (is (.exists (io/as-file result-path)))
     (is (= 128 (.getWidth img)))
-    (is (= 64 (.getHeight img))))
-    (io/delete-file png-output-path true))
+    (is (= 64 (.getHeight img)))
+    (io/delete-file png-output-path true)))
 
 (deftest test-does-jpeg-transcoder-work-without-options
   (io/delete-file jpeg-output-path true) 
@@ -43,10 +44,10 @@
         result-path (t/to-jpeg the-doc jpeg-output-path)]
     (is (-> result-path nil? not))
     (is (= jpeg-output-path result-path))
-    (is (.exists (io/as-file result-path))))
-    (io/delete-file jpeg-output-path true))
+    (is (.exists (io/as-file result-path)))
+    (io/delete-file jpeg-output-path true)))
 
-(deftest test-does-jpeg-transoder-work-with-options
+(deftest test-does-jpeg-transcoder-work-with-options
   (io/delete-file jpeg-output-path true) 
   (let [options {:width 128 :height 64}
         the-doc (make-dummy-svg)
@@ -55,6 +56,19 @@
     (is (= jpeg-output-path result-path))
     (is (.exists (io/as-file result-path)))
     (is (= 128 (.getWidth img)))
-    (is (= 64 (.getHeight img))))
-    (io/delete-file jpeg-output-path true))
+    (is (= 64 (.getHeight img)))
+    (io/delete-file jpeg-output-path true)))
 
+(deftest test-indexed
+  (let [options {:indexed 1}
+        the-doc (make-dummy-svg)
+        result-path (t/to-png the-doc png-output-path options)
+        img (ImageIO/read (io/as-file result-path))]
+    (is (= BufferedImage/TYPE_BYTE_BINARY (.getType img)))
+    (io/delete-file png-output-path true))
+  (let [options {:indexed 16}
+        the-doc (make-dummy-svg)
+        result-path (t/to-png the-doc png-output-path options)
+        img (ImageIO/read (io/as-file result-path))]
+    (is (= BufferedImage/TYPE_4BYTE_ABGR (.getType img)))
+    (io/delete-file png-output-path true)))


### PR DESCRIPTION
This change adds a new `:indexed` transcoder hint option for PNG files which can be used to generate non-truecolor images.  To support this option, I had to add support for non-float transcoder hints by attaching a coercing function to each defined hint.

Also, a .gitignore file has been added.